### PR TITLE
Docker Image erstellung

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 elm-stuff/
 dist/
+todos.db

--- a/Backend/Haskell/.dockerignore
+++ b/Backend/Haskell/.dockerignore
@@ -1,0 +1,5 @@
+.gitignore
+.vscode/
+todos.db
+settings.yaml
+.stack-work/

--- a/Backend/Haskell/app/Main.hs
+++ b/Backend/Haskell/app/Main.hs
@@ -1,6 +1,15 @@
 module Main where
 
 import App (startApp)
+import System.Environment (getArgs)
 
 main :: IO ()
-main = startApp "./settings.yaml"
+main = do
+  args <- getArgs
+  case args of
+    [] -> do
+      putStrLn "using local settings file"
+      startApp "./settings.yaml"
+    settingsPath:_ -> do
+      putStrLn $ "using " ++ settingsPath
+      startApp settingsPath

--- a/Backend/Haskell/makefile
+++ b/Backend/Haskell/makefile
@@ -9,3 +9,8 @@ run: build
 .PHONY: clean
 clean: 
 	rm -rf .stack-work
+	rm -rf ./dist
+
+deploy: build
+	mkdir -p ./dist
+	cp $(shell stack path --local-install-root)/bin/. ./dist/ -a

--- a/Backend/Haskell/src/App.hs
+++ b/Backend/Haskell/src/App.hs
@@ -35,7 +35,7 @@ startApp :: FilePath -> IO ()
 startApp settingsPath = do
   Settings{..} <- loadSettings settingsPath
 
-  writeDocs "docs.md"
+  -- writeDocs "docs.md"
   putStrLn $ "initializing Database in " ++ databasePath
   dbHandle <- Db.initDb databasePath
 

--- a/Backend/Haskell/src/Page.hs
+++ b/Backend/Haskell/src/Page.hs
@@ -33,7 +33,7 @@ scripts :: H.Html
 scripts = do
   traverse_ (\ref -> H.script "" ! A.src ref) jsSrcs
   H.script $ H.toHtml $ unlines
-    [ "Elm.Main.init({ flags: { baseUrlPath: '', apiUrl: '' } });" ]
+    [ "Elm.Main.init({ flags: { baseUrlPath: '', apiUrl: '/api' } });" ]
   where
     jsSrcs =
       [ "static/todo.js" ]

--- a/Backend/Haskell/src/Page.hs
+++ b/Backend/Haskell/src/Page.hs
@@ -33,8 +33,7 @@ scripts :: H.Html
 scripts = do
   traverse_ (\ref -> H.script "" ! A.src ref) jsSrcs
   H.script $ H.toHtml $ unlines
-    [ "Elm.Main.init({ flags: { baseUrl: '/' } });" ]
-
+    [ "Elm.Main.init({ flags: { baseUrlPath: '', apiUrl: '' } });" ]
   where
     jsSrcs =
       [ "static/todo.js" ]

--- a/Backend/Haskell/src/Settings.hs
+++ b/Backend/Haskell/src/Settings.hs
@@ -22,17 +22,23 @@ data Settings = Settings
 $(deriveJSON defaultOptions ''Settings)
 
 defaultSettings :: IO Settings
-defaultSettings = 
+defaultSettings =
   Settings 8080 "./todos.db" <$> Auth.newConfig
 
 loadSettings :: FilePath -> IO Settings
 loadSettings settingsPath = do
   res <- decodeFileEither settingsPath
-  either fallback pure res
+  either fallback success res
   where fallback _ = do
+          putStrLn $ "could not load " ++ settingsPath ++  " falling back to default.."
           def <- defaultSettings
           saveSettings def settingsPath
           pure def
+        success settings = do
+          putStrLn $ "successfully loaded " ++ settingsPath ++ "\n"
+            ++ "db-path: " ++ databasePath settings
+            ++ "\nserverPort: " ++ show (serverPort settings) ++ "\n"
+          pure settings
 
 saveSettings :: Settings -> FilePath -> IO ()
 saveSettings settings settingsPath =

--- a/Docker/app/dockerfile
+++ b/Docker/app/dockerfile
@@ -19,24 +19,25 @@ WORKDIR /app
 COPY ./Backend/Haskell/stack.yaml ./Backend/Haskell/TodoServer.cabal ./
 RUN stack setup && stack install --dependencies-only
 
-COPY ./BackEnd/Haskell .
+COPY ./Backend/Haskell .
 RUN make deploy
 
 
-FROM fpco/stack-run:lts-14.6
+FROM ubuntu:18.04  
 EXPOSE 8080
 
-ENV LANG en_US.UTF-8
+RUN apt-get update && apt-get install -y libgmp-dev && rm -rf /var/lib/apt/lists/*
 
 RUN mkdir -p /app
 WORKDIR /app
-COPY --from=haskellBuilder /dist /app
+COPY --from=haskellBuilder /app/dist /app
 
 RUN mkdir -p static
-COPY --from=haskellBuilder /app/static .
+COPY --from=haskellBuilder /app/static ./static
 COPY --from=elmBuilder /app/dist/todo.js ./static/
 
 RUN useradd app
+RUN chown -hR app /app
 USER app
 
 ENTRYPOINT [ ]

--- a/Docker/app/dockerfile
+++ b/Docker/app/dockerfile
@@ -3,7 +3,8 @@ ENV BUILD=/app
 RUN mkdir -p $BUILD
 RUN mkdir -p $BUILD/dist
 WORKDIR $BUILD
-COPY ./Elm .
+COPY ./Elm/src ./src
+COPY ./Elm/elm.json .
 RUN elm make ./src/Main.elm --output ./dist/todo.js
 
 FROM fpco/stack-build:lts-14.6 as haskellBuilder
@@ -15,10 +16,10 @@ RUN mkdir -p /app
 RUN mkdir -p /app/dist
 WORKDIR /app
 
-COPY ./Backend/Haskell/stack.yaml ./Backend/Haskell/TodoServer.cabal /app/
+COPY ./Backend/Haskell/stack.yaml ./Backend/Haskell/TodoServer.cabal ./
 RUN stack setup && stack install --dependencies-only
 
-COPY . /app
+COPY ./BackEnd/Haskell .
 RUN make deploy
 
 

--- a/Docker/app/dockerfile
+++ b/Docker/app/dockerfile
@@ -1,0 +1,42 @@
+FROM codesimple/elm:0.19 as elmBuilder
+ENV BUILD=/app
+RUN mkdir -p $BUILD
+RUN mkdir -p $BUILD/dist
+WORKDIR $BUILD
+COPY ./Elm .
+RUN elm make ./src/Main.elm --output ./dist/todo.js
+
+FROM fpco/stack-build:lts-14.6 as haskellBuilder
+
+ENV LANG en_US.UTF-8
+ENV PATH /root/.local/bin:$PATH
+
+RUN mkdir -p /app
+RUN mkdir -p /app/dist
+WORKDIR /app
+
+COPY ./Backend/Haskell/stack.yaml ./Backend/Haskell/TodoServer.cabal /app/
+RUN stack setup && stack install --dependencies-only
+
+COPY . /app
+RUN make deploy
+
+
+FROM fpco/stack-run:lts-14.6
+EXPOSE 8080
+
+ENV LANG en_US.UTF-8
+
+RUN mkdir -p /app
+WORKDIR /app
+COPY --from=haskellBuilder /dist /app
+
+RUN mkdir -p static
+COPY --from=haskellBuilder /app/static .
+COPY --from=elmBuilder /app/dist/todo.js ./static/
+
+RUN useradd app
+USER app
+
+ENTRYPOINT [ ]
+CMD ["/app/TodoServer-exe"]

--- a/Docker/app/dockerfile
+++ b/Docker/app/dockerfile
@@ -28,7 +28,7 @@ EXPOSE 8080
 
 RUN apt-get update && apt-get install -y libgmp-dev && rm -rf /var/lib/apt/lists/*
 
-RUN mkdir -p /app
+RUN mkdir -p /app && mkdir -p /data
 WORKDIR /app
 COPY --from=haskellBuilder /app/dist /app
 
@@ -36,9 +36,7 @@ RUN mkdir -p static
 COPY --from=haskellBuilder /app/static ./static
 COPY --from=elmBuilder /app/dist/todo.js ./static/
 
-RUN useradd app
-RUN chown -hR app /app
+RUN useradd app && chown -hR app /app && chown -hR app /data
 USER app
 
-ENTRYPOINT [ ]
-CMD ["/app/TodoServer-exe"]
+ENTRYPOINT ["/app/TodoServer-exe", "/data/settings.yaml"]

--- a/Docker/app/dockerfile
+++ b/Docker/app/dockerfile
@@ -5,7 +5,7 @@ RUN mkdir -p $BUILD/dist
 WORKDIR $BUILD
 COPY ./Elm/src ./src
 COPY ./Elm/elm.json .
-RUN elm make ./src/Main.elm --output ./dist/todo.js
+RUN elm make --optimize ./src/Main.elm --output ./dist/todo.js
 
 FROM fpco/stack-build:lts-14.6 as haskellBuilder
 

--- a/Docker/docker-compose.yml
+++ b/Docker/docker-compose.yml
@@ -1,0 +1,12 @@
+version: '3.3'
+
+services:
+  app:
+    build:
+      context: .
+      dockerfile: ./Docker/app/dockerfile
+    container_name: todo-app
+    restart: unless-stopped
+    command: "/app/TodoServer-exe"
+    environment:
+      PORT: 8080

--- a/Elm/.dockerignore
+++ b/Elm/.dockerignore
@@ -1,0 +1,5 @@
+.gitignore
+.vscode/
+elm-stuff/
+node_modules/
+dist/

--- a/Elm/index.js
+++ b/Elm/index.js
@@ -1,6 +1,6 @@
 import { Elm } from './src/Main.elm'
 // TODO: change to public API Url later
-var app = Elm.Main.init({ flags: { baseUrlPath: "", apiUrl: "http://localhost:8080" } });
+var app = Elm.Main.init({ flags: { baseUrlPath: "", apiUrl: "http://localhost:8080/api" } });
 
 app.ports.store.subscribe(function(data) {
     let storageKey = data[0];

--- a/Elm/makefile
+++ b/Elm/makefile
@@ -1,0 +1,17 @@
+.PHONY: build
+build:
+	npm run build
+
+.PHONY: release
+release:
+	npm run release
+
+deploy: build
+	cp ./node_modules/todomvc-app-css/index.css ../dist/static/index.css
+	cp ./node_modules/todomvc-common/base.css ../dist/static/base.css
+	cp ./dist/app.js ../dist/static/todo.js
+
+.PHONY: clean
+clean: 
+	rm -rf elm-stuff
+	rm -rf dist

--- a/data/settings.yaml
+++ b/data/settings.yaml
@@ -1,0 +1,6 @@
+serverPort: 8080
+authConfig:
+  jwtKey:
+    k: OpZDHdArPUQS1a7Oh360NdwALl7_m5C9p5_RLxe1V0K-eDzXpp2Z9YRAWiy1-yWnu3uBpJXDOQiE9WMDj44AJUfUVbOSoUlTReLhJZyVYi2uqX7BnaWSZ2N0jGZHDVqfS6rqGhnmaaILAU1V8Yg-FppU00au7Y-qX3eIHDd6KdMebcHJE3OXBat66a0xwk074KqNK5ct9I3zOjekuUpCNwC3wN7OCeigSckP2imCcKaDiZ3l4G0U8MrYSoQQgLpAiI8ucWJXHC2ZbyXzOgzeMemg9dzBXfvKzZnrEUGQy8CPCSGXXCT1lG2Y1PeSP3C-9lwIdoaQk7BCsg75SW1fiA
+    kty: oct
+databasePath: /data/todos.db

--- a/makefile
+++ b/makefile
@@ -1,0 +1,38 @@
+.PHONY: build
+build: elm
+	$(MAKE) -C Backend/Haskell build
+
+.PHONY: elm
+elm:
+	$(MAKE) -C Elm build
+
+.PHONY: deploy	
+deploy:
+	$(shell mkdir -p ./dist)
+	$(shell mkdir -p ./dist/static)
+	cp ./Backend/Haskell/static/* ./dist/static/ -r
+	$(MAKE) -C Elm deploy
+	$(MAKE) -C Backend/Haskell deploy
+	cp ./Backend/Haskell/dist/* ./dist/ -r
+
+.PHONY: clean
+clean: 
+	$(MAKE) -C Elm clean
+	$(MAKE) -C Backend/Haskell clean
+	rm -rf ./dist
+
+.PHONY: docker-build
+docker-build:
+	docker-compose -f ./Docker/docker-compose.yml --project-directory . -p todo build --force-rm
+
+.PHONY: docker-run
+docker-run:
+	docker-compose -f ./Docker/docker-compose.yml --project-directory . -p todo up
+
+.PHONY: docker-install
+docker-install:
+	docker-compose -f ./Docker/docker-compose.yml --project-directory . -p todo up -d
+
+.PHONY: docker-clean
+docker-clean:
+	docker-compose -f ./Docker/docker-compose.yml --project-directory . -p todo rm -s -f -v

--- a/makefile
+++ b/makefile
@@ -16,7 +16,7 @@ deploy:
 	cp ./Backend/Haskell/dist/* ./dist/ -r
 
 .PHONY: clean
-clean: 
+clean:
 	$(MAKE) -C Elm clean
 	$(MAKE) -C Backend/Haskell clean
 	rm -rf ./dist
@@ -27,4 +27,4 @@ docker-build:
 
 .PHONY: docker-run
 docker-run: docker-build
-	docker run -ti --rm -p8080:8080 todo-server
+	docker run -ti --rm -p 8080:8080 -v $(shell pwd)/data:/data todo-server

--- a/makefile
+++ b/makefile
@@ -6,7 +6,7 @@ build: elm
 elm:
 	$(MAKE) -C Elm build
 
-.PHONY: deploy	
+.PHONY: deploy
 deploy:
 	$(shell mkdir -p ./dist)
 	$(shell mkdir -p ./dist/static)
@@ -23,16 +23,8 @@ clean:
 
 .PHONY: docker-build
 docker-build:
-	docker-compose -f ./Docker/docker-compose.yml --project-directory . -p todo build --force-rm
+	docker build -t todo-server -f ./Docker/app/dockerfile .
 
 .PHONY: docker-run
-docker-run:
-	docker-compose -f ./Docker/docker-compose.yml --project-directory . -p todo up
-
-.PHONY: docker-install
-docker-install:
-	docker-compose -f ./Docker/docker-compose.yml --project-directory . -p todo up -d
-
-.PHONY: docker-clean
-docker-clean:
-	docker-compose -f ./Docker/docker-compose.yml --project-directory . -p todo rm -s -f -v
+docker-run: docker-build
+	docker run -ti --rm -p8080:8080 todo-server


### PR DESCRIPTION
Bündelt die Haskell und die Elm App gemeinsam in einem Container

Dabei gibt Servant eine einfache index-html Seite aus um die Elm-App zu laden

- `sudo make docker-build` erstellt ein Docker-Image `todo-server`
- `sudo make docker-run` erstellt es und führt es anschließend interaktiv aus

## Probleme 

- die Navigation in der Elm-App scheint nicht zu gehen
- das Styling für die Listen ist off (eingetragene Items sehen wie Links aus)
- eine Liste mit Namen "DevOpenSpace 2019" erscheint in der Todo-Ansicht übereinandergedruckt "DevOpenSpace" über/unter "2019"

## noch zu tun

- settings und database lokal speichern und in den Container verlinken