### PR TITLE
Dockerized app fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 elm-stuff/
 dist/
 todos.db
+*.tar.gz

--- a/Backend/Haskell/src/Page.hs
+++ b/Backend/Haskell/src/Page.hs
@@ -39,7 +39,11 @@ scripts :: Config -> H.Html
 scripts Config{..} = do
   traverse_ (\ref -> H.script "" ! A.src ref) jsSrcs
   H.script $ H.toHtml $ unlines
-    [ "Elm.Main.init({ flags: { baseUrlPath: '" ++ siteBaseUrl ++ "', apiUrl: '" ++ apiBaseUrl ++ "' } });" ]
+    [ "var app = Elm.Main.init({ flags: { baseUrlPath: '" ++ siteBaseUrl ++ "', apiUrl: '" ++ apiBaseUrl ++ "' } });"
+    , "window.initPorts(app);"
+    ]
   where
     jsSrcs =
-      [ fromString $ siteBaseUrl ++ "static/todo.js" ]
+      [ fromString $ siteBaseUrl ++ "static/ports.js"
+      , fromString $ siteBaseUrl ++ "static/todo.js"
+      ]

--- a/Backend/Haskell/static/style.css
+++ b/Backend/Haskell/static/style.css
@@ -1,3 +1,12 @@
-body {
-  color: steelblue
+.todo-list a {
+    text-decoration: none;
+    color: inherit;
+    cursor: pointer;
+}
+
+.open-count {
+    position: absolute;
+    padding: 15px;
+    line-height: 1.2;
+    color: lightgray;
 }

--- a/Docker/app/dockerfile
+++ b/Docker/app/dockerfile
@@ -5,7 +5,8 @@ RUN mkdir -p $BUILD/dist
 WORKDIR $BUILD
 COPY ./Elm/src ./src
 COPY ./Elm/elm.json .
-RUN elm make --optimize ./src/Main.elm --output ./dist/todo.js
+COPY ./Elm/ports.js .
+RUN elm make ./src/Main.elm --output ./dist/todo.js
 
 FROM fpco/stack-build:lts-14.6 as haskellBuilder
 
@@ -34,6 +35,7 @@ COPY --from=haskellBuilder /app/dist /app
 
 RUN mkdir -p static
 COPY --from=haskellBuilder /app/static ./static
+COPY --from=elmBuilder /app/ports.js ./static/
 COPY --from=elmBuilder /app/dist/todo.js ./static/
 
 RUN useradd app && chown -hR app /app && chown -hR app /data

--- a/Elm/index.html
+++ b/Elm/index.html
@@ -23,6 +23,7 @@
 </style>
 
 <body>
+    <script src="./ports.js"></script>
     <script src="./index.js"></script>
 </body>
 

--- a/Elm/index.js
+++ b/Elm/index.js
@@ -1,20 +1,4 @@
 import { Elm } from './src/Main.elm'
 // TODO: change to public API Url later
-var app = Elm.Main.init({ flags: { baseUrlPath: "", apiUrl: "http://localhost:8080/api" } });
-
-app.ports.store.subscribe(function(data) {
-    let storageKey = data[0];
-    let value = data[1];
-    if (value === null) {
-        localStorage.removeItem(storageKey);
-    } else {
-        localStorage.setItem(storageKey, value);
-    }
-});
-
-app.ports.request.subscribe(function(storageKey) {
-   let value = localStorage.getItem(storageKey);
-   if(app.ports.receive) {
-       app.ports.receive.send([storageKey, value])
-   }
-});
+var app = Elm.Main.init({ flags: { baseUrlPath: "/", apiUrl: "https://leastfixedpoint.net/todo/api" } });
+window.initPorts(app);

--- a/Elm/makefile
+++ b/Elm/makefile
@@ -9,6 +9,7 @@ release:
 deploy: build
 	cp ./node_modules/todomvc-app-css/index.css ../dist/static/index.css
 	cp ./node_modules/todomvc-common/base.css ../dist/static/base.css
+	cp ./dist/ports.js ../dist/static/ports.js
 	cp ./dist/app.js ../dist/static/todo.js
 
 .PHONY: clean

--- a/Elm/package.json
+++ b/Elm/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "start": "parcel serve index.html --no-cache",
     "build": "elm make ./src/Main.elm --output ./dist/app.js",
-    "release": "cp node_modules/todomvc-app-css/index.css ../Backend/Haskell/static/index.css && cp node_modules/todomvc-common/base.css ../Backend/Haskell/static/base.css && elm make ./src/Main.elm --optimize --output ../Backend/Haskell/static/todo.js"
+    "release": "cp node_modules/todomvc-app-css/index.css ../Backend/Haskell/static/index.css && cp node_modules/todomvc-common/base.css ../Backend/Haskell/static/base.css && cp ports.js ../Backend/Haskell/static/ports.js && elm make ./src/Main.elm --optimize --output ../Backend/Haskell/static/todo.js"
   },
   "author": "Moritz Großmann, Carsten König",
   "license": "ISC",

--- a/Elm/ports.js
+++ b/Elm/ports.js
@@ -1,0 +1,18 @@
+window.initPorts = function (app) {
+  app.ports.store.subscribe(function (data) {
+    let storageKey = data[0];
+    let value = data[1];
+    if (value === null) {
+      localStorage.removeItem(storageKey);
+    } else {
+      localStorage.setItem(storageKey, value);
+    }
+  });
+
+  app.ports.request.subscribe(function (storageKey) {
+    let value = localStorage.getItem(storageKey);
+    if (app.ports.receive) {
+      app.ports.receive.send([storageKey, value])
+    }
+  });
+}

--- a/Elm/src/Main.elm
+++ b/Elm/src/Main.elm
@@ -32,22 +32,30 @@ init flags location key =
         ( session, sessionCmd ) =
             Session.init flags key
     in
-    case Routes.locationToRoute flags.baseUrlPath location of
-        Just route ->
-            initPage session route
+    let
+        ( model, cmd ) =
+            case Routes.locationToRoute flags.baseUrlPath location of
+                Just route ->
+                    initPage session route
 
-        Nothing ->
-            let
-                ( initModel, initCmd ) =
-                    initPage session Routes.Login
-            in
-            ( initModel
-            , Cmd.batch
-                [ Nav.replaceUrl key (Routes.routeToUrlString flags.baseUrlPath Routes.Login)
-                , initCmd
-                , sessionCmd
-                ]
-            )
+                Nothing ->
+                    let
+                        ( initModel, initCmd ) =
+                            initPage session Routes.Login
+                    in
+                    ( initModel
+                    , Cmd.batch
+                        [ Nav.replaceUrl key (Routes.routeToUrlString flags.baseUrlPath Routes.Login)
+                        , initCmd
+                        ]
+                    )
+    in
+    ( model
+    , Cmd.batch
+        [ cmd
+        , sessionCmd
+        ]
+    )
 
 
 type Model

--- a/Elm/src/Page/LoginPending.elm
+++ b/Elm/src/Page/LoginPending.elm
@@ -61,4 +61,4 @@ subscriptions _ =
 
 view : Model -> Html Msg
 view _ =
-    H.div [] []
+    H.div [] [ H.text "login pending..." ]

--- a/Elm/src/Routes.elm
+++ b/Elm/src/Routes.elm
@@ -70,6 +70,6 @@ route baseUrl =
     in
     UrlP.oneOf
         [ UrlP.map List (basePart </> UrlP.s "lists" </> UrlP.int </> UrlP.fragment filterParser)
-        , UrlP.map Login (basePart </> UrlP.s "login")
         , UrlP.map Lists (basePart </> UrlP.s "lists")
+        , UrlP.map Login (basePart </> UrlP.s "login")
         ]

--- a/data/settings.yaml
+++ b/data/settings.yaml
@@ -4,5 +4,5 @@ authConfig:
     k: OpZDHdArPUQS1a7Oh360NdwALl7_m5C9p5_RLxe1V0K-eDzXpp2Z9YRAWiy1-yWnu3uBpJXDOQiE9WMDj44AJUfUVbOSoUlTReLhJZyVYi2uqX7BnaWSZ2N0jGZHDVqfS6rqGhnmaaILAU1V8Yg-FppU00au7Y-qX3eIHDd6KdMebcHJE3OXBat66a0xwk074KqNK5ct9I3zOjekuUpCNwC3wN7OCeigSckP2imCcKaDiZ3l4G0U8MrYSoQQgLpAiI8ucWJXHC2ZbyXzOgzeMemg9dzBXfvKzZnrEUGQy8CPCSGXXCT1lG2Y1PeSP3C-9lwIdoaQk7BCsg75SW1fiA
     kty: oct
 databasePath: /data/todos.db
-siteBaseUrl: /todo/
-apiBaseUrl: /todo/api
+siteBaseUrl: /
+apiBaseUrl: /api

--- a/makefile
+++ b/makefile
@@ -28,3 +28,7 @@ docker-build:
 .PHONY: docker-run
 docker-run: docker-build
 	docker run -ti --rm -p 8080:8080 -v $(shell pwd)/data:/data todo-server
+
+.PHONY: docker-pack
+docker-pack: docker-build
+	docker save todo-server | gzip > todo-server.tar.gz


### PR DESCRIPTION
Ist ein bisschen hacky, aber ich wollte eine einfache Möglichkeit die Ports sowohl aus *parcel*, als auch aus meiner Mini-Seite aus aufzurufen, deswegen habe ich das in eine einfache `.js` Datei verschoben, die die Initialisierungsfunktion einfach an das `window`-Objekt hängt.

Ist sicher **nicht** Industriestandard - wenn Du magst kannst Du versuchen das zu ändern - am besten wäre sicher, wenn Du da ein Common-JS Modul draus machst und das in der `index.js` importest.

Dann müssten wir in den Elm-Builder Container aber Parcel mit aufnehmen und Parcel nutzen um alle JS Dateien / CSS usw. zu bundeln (also was es eigentlich machen soll) - dann müsste ich nur diese Bundels in das static Verzeichnis, des End-Containers stecken und die nutzen.

Wenn Du Lust hast kannst Du das ja mal versuchen.

Für den Moment geht der Hack.